### PR TITLE
ci: add UpdateCLI GitHub Actions workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,49 @@
+---
+name: Updatecli
+
+on:
+  # Trigger Updatecli if a new commit land on the main branch
+  push:
+    branches: [ main ]
+  # Manually trigger Updatecli via GitHub UI
+  workflow_dispatch:
+  # Trigger Updatecli once day by a cronjob
+  schedule:
+  # * is a special character in YAML, so you have to quote this string
+  # Run once a day
+  - cron: '0 0 * * *'
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Install Updatecli in the runner
+      uses: updatecli/updatecli-action@v2
+
+    - uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b # v5
+      id: kubectl
+
+    - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      id: helm
+      with:
+        version: '3.19.4'
+
+    - name: Get token
+      id: get_token
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+      with:
+        app-id: ${{ secrets.UPDATECLI_APP_ID }}
+        private-key: ${{ secrets.UPDATECLI_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Run Updatecli in apply mode
+      run: "updatecli --experimental apply --config ./updatecli/updatecli.d --values updatecli/values.yaml --clean=true"
+      env:
+        UPDATECLI_GITHUB_TOKEN: '${{ steps.get_token.outputs.token }}'


### PR DESCRIPTION
## Summary
- Add missing UpdateCLI workflow to trigger chart update pipelines
- Runs daily, on push to main, and on manual dispatch
- Uses GitHub App token (same pattern as all other opzkit repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)